### PR TITLE
Upgrade npm to 2.14.14

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ scalaVersion := "2.10.4"
 
 libraryDependencies ++= Seq(
   "com.typesafe" %% "jse" % "1.1.2",
-  "org.webjars" % "npm" % "2.11.2",
+  "org.webjars" % "npm" % "2.14.14",
   "com.typesafe.akka" %% "akka-actor" % "2.3.11",
   "org.webjars" % "webjars-locator" % "0.25",
   "org.specs2" %% "specs2-core" % "3.4" % "test",


### PR DESCRIPTION
Merging in the webjars upgrade locally.  Will need to branch / tag for 1.1.2 (or 1.2?  Minor or major upgrade?)

Following on from https://github.com/webjars/npm/pull/4.  Tested with sbt-js-engine using `sbt scripted` with no errors:

```
> scripted
[warn] Credentials file /Users/wsargent/.bintray/.credentials does not exist
[info] Updating {file:/Users/wsargent/work/sbt-js-engine/}sbt-js-engine...
[info] Resolving org.scala-sbt.ivy#ivy;2.3.0-sbt-fccfbd44c9f64523b61398a0155784d[info] Resolving org.scala-sbt#sbt-launch;0.13.8 ...
[info] Done updating.
[info] :: delivering :: com.typesafe.sbt#sbt-js-engine;1.1.4-SNAPSHOT :: 1.1.4-SNAPSHOT :: integration :: Tue Jan 05 15:11:25 PST 2016
[info]  delivering ivy file to /Users/wsargent/work/sbt-js-engine/target/scala-2.10/sbt-0.13/ivy-1.1.4-SNAPSHOT.xml
[info] Packaging /Users/wsargent/work/sbt-js-engine/target/scala-2.10/sbt-0.13/sbt-js-engine-1.1.4-SNAPSHOT.jar ...
[info] Done packaging.
[info]  published sbt-js-engine to /Users/wsargent/.ivy2/local/com.typesafe.sbt/sbt-js-engine/scala_2.10/sbt_0.13/1.1.4-SNAPSHOT/jars/sbt-js-engine.jar
[info]  published sbt-js-engine to /Users/wsargent/.ivy2/local/com.typesafe.sbt/sbt-js-engine/scala_2.10/sbt_0.13/1.1.4-SNAPSHOT/srcs/sbt-js-engine-sources.jar
[info]  published sbt-js-engine to /Users/wsargent/.ivy2/local/com.typesafe.sbt/sbt-js-engine/scala_2.10/sbt_0.13/1.1.4-SNAPSHOT/docs/sbt-js-engine-javadoc.jar
[info]  published ivy to /Users/wsargent/.ivy2/local/com.typesafe.sbt/sbt-js-engine/scala_2.10/sbt_0.13/1.1.4-SNAPSHOT/ivys/ivy.xml
Running sbt-js-engine / jstask
Running sbt-js-engine / npm
Running sbt-js-engine / npmsubmodule
[success] Total time: 60 s, completed Jan 5, 2016 3:12:24 PM
```
