### PR TITLE
Update webjars-locator-core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 dist: trusty
 
-jdk: oraclejdk8
 language: scala
 
+env:
+  - TRAVIS_JDK=8
+
+before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
 install:
+  - jabba install "adopt@~1.$TRAVIS_JDK.0-0" && jabba use "$_" && java -Xmx32m -version
   - nvm install 7.9.0
 
 script: sbt +test

--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ Some sample usage from Scala:
 ```scala
     val engine = system.actorOf(Node.props(), "engine")
     val to = new File(new File("target"), "webjars")
-    val cacheFile = new File(to, "extraction-cache")
     
-    val npm = new Npm(engine, NpmLoader.load(to, cacheFile, Main.getClass.getClassLoader))
+    val npm = new Npm(engine, NpmLoader.load(to, Main.getClass.getClassLoader))
     
     for (
       result <- npm.update()  // Perform an "npm update"

--- a/build.sbt
+++ b/build.sbt
@@ -2,19 +2,19 @@ organization := "com.typesafe"
 name := "npm"
 
 scalaVersion := "2.10.7"
-crossScalaVersions := Seq(scalaVersion.value, "2.11.12", "2.12.7")
+crossScalaVersions := Seq(scalaVersion.value, "2.11.12", "2.12.10")
 
 libraryDependencies ++= {
   val akkaVersion = scalaBinaryVersion.value match {
     case "2.10" => "2.3.16"
-    case "2.11" => "2.3.16"
-    case "2.12" => "2.5.18"
+    case "2.11" => "2.5.26"
+    case "2.12" => "2.6.0"
   }
   Seq(
     "com.typesafe" %% "jse" % "1.2.4",
     "org.webjars" % "npm" % "5.0.0-2",
     "com.typesafe.akka" %% "akka-actor" % akkaVersion,
-    "org.webjars" % "webjars-locator-core" % "0.36",
+    "org.webjars" % "webjars-locator-core" % "0.43",
     "commons-io" % "commons-io" % "2.6" % "test",
     "org.specs2" %% "specs2-core" % "3.10.0" % "test",
     "junit" % "junit" % "4.12" % "test"

--- a/npm-tester/src/main/scala/com/typesafe/npm/tester/Main.scala
+++ b/npm-tester/src/main/scala/com/typesafe/npm/tester/Main.scala
@@ -21,8 +21,7 @@ object Main {
 
     val engine = system.actorOf(Node.props(), "engine")
     val to = new File(new File("target"), "webjars")
-    val cacheFile = new File(to, "extraction-cache")
-    val npm = new Npm(engine, NpmLoader.load(to, cacheFile, Main.getClass.getClassLoader))
+    val npm = new Npm(engine, NpmLoader.load(to, Main.getClass.getClassLoader))
     for (
       result <- npm.update()
     ) yield {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18

--- a/src/main/scala/com/typesafe/npm/Npm.scala
+++ b/src/main/scala/com/typesafe/npm/Npm.scala
@@ -40,22 +40,18 @@ class Npm(engine: ActorRef, npmFile: File, verbose: Boolean = false) {
 }
 
 
-import org.webjars.FileSystemCache
 import org.webjars.WebJarExtractor
 
 object NpmLoader {
   /**
    * Extract the NPM WebJar to disk and return its main entry point.
    * @param to The directory to extract to.
-   * @param cacheFile The file to use as a cache of extractions (we don't extract unless we need to).
    * @param classLoader The classloader that should be used to locate the Node related WebJars.
    * @return The main JavaScript entry point into NPM.
    */
-  def load(to: File, cacheFile: File, classLoader: ClassLoader): File = {
-    val cache = new FileSystemCache(cacheFile)
-    val extractor = new WebJarExtractor(cache, classLoader)
+  def load(to: File, classLoader: ClassLoader): File = {
+    val extractor = new WebJarExtractor(classLoader)
     extractor.extractAllNodeModulesTo(to)
-    cache.save()
     new File(to, "npm" + File.separator + "lib" + File.separator + "npm.js")
   }
 }

--- a/src/test/scala-2.11/com/typesafe/npm/AkkaCompat.scala
+++ b/src/test/scala-2.11/com/typesafe/npm/AkkaCompat.scala
@@ -1,10 +1,11 @@
 package com.typesafe.npm
 
 import akka.actor.ActorSystem
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 object AkkaCompat {
   def terminate(system: ActorSystem): Unit = {
-    system.shutdown()
-    system.awaitTermination()
+    Await.ready(system.terminate(), 10.seconds)
   }
 }

--- a/src/test/scala/com/typesafe/npm/NpmSpec.scala
+++ b/src/test/scala/com/typesafe/npm/NpmSpec.scala
@@ -31,8 +31,7 @@ class NpmSpec extends Specification {
           FileUtils.deleteDirectory(new File("node_modules"));
 
           val to = new File(new File("target"), "webjars")
-          val cacheFile = new File(to, "extraction-cache")
-          val npm = new Npm(engine, NpmLoader.load(to, cacheFile, this.getClass.getClassLoader), verbose = true)
+          val npm = new Npm(engine, NpmLoader.load(to, this.getClass.getClassLoader), verbose = true)
           val pendingResult = npm.update()
 
           val result = Await.result(pendingResult, timeout.duration)


### PR DESCRIPTION
Looks like `webjars-locator-core` removed its caching mechanism [from v0.38 to v0.39](https://github.com/webjars/webjars-locator-core/compare/webjars-locator-core-0.38...webjars-locator-core-0.39):
https://github.com/webjars/webjars-locator-core/pull/28/files#diff-36bf61d169f1bb6b49ea0c1e4f7d62e1L53